### PR TITLE
fix: handle null in deepMerge and add unit test

### DIFF
--- a/src/utilities/deepMerge.ts
+++ b/src/utilities/deepMerge.ts
@@ -7,7 +7,7 @@
  * @returns {boolean}
  */
 export function isObject(item: unknown): item is object {
-  return typeof item === 'object' && !Array.isArray(item)
+  return item !== null && typeof item === 'object' && !Array.isArray(item)
 }
 
 /**
@@ -16,20 +16,22 @@ export function isObject(item: unknown): item is object {
  * @param ...sources
  */
 export default function deepMerge<T, R>(target: T, source: R): T {
-  const output = { ...target }
-  if (isObject(target) && isObject(source)) {
-    Object.keys(source).forEach((key) => {
-      if (isObject(source[key])) {
-        if (!(key in target)) {
-          Object.assign(output, { [key]: source[key] })
-        } else {
-          output[key] = deepMerge(target[key], source[key])
-        }
-      } else {
-        Object.assign(output, { [key]: source[key] })
-      }
-    })
+  if (!isObject(target) || !isObject(source)) {
+    return source as unknown as T
   }
+
+  const output = { ...target }
+  Object.keys(source).forEach((key) => {
+    if (isObject(source[key])) {
+      if (!(key in target)) {
+        Object.assign(output, { [key]: source[key] })
+      } else {
+        output[key] = deepMerge(target[key], source[key])
+      }
+    } else {
+      Object.assign(output, { [key]: source[key] })
+    }
+  })
 
   return output
 }

--- a/tests/unit/deepMerge.spec.ts
+++ b/tests/unit/deepMerge.spec.ts
@@ -1,0 +1,10 @@
+import deepMerge from '@/utilities/deepMerge'
+import { describe, it, expect } from 'vitest'
+
+describe('deepMerge', () => {
+  it('replaces null without attempting to merge it', () => {
+    const target = { a: null }
+    const source = { a: { b: 1 } }
+    expect(deepMerge(target, source)).toEqual({ a: { b: 1 } })
+  })
+})


### PR DESCRIPTION
## Summary
- ensure `deepMerge` replaces null targets with source objects
- add a unit test covering null-handling behavior

## Testing
- `pnpm exec vitest run --config vitest.unit.config.mts`
- `pnpm test tests/unit/deepMerge.spec.ts` *(fails: missing secret key)*
- `pnpm lint src/utilities/deepMerge.ts tests/unit/deepMerge.spec.ts` *(fails: Couldn't find any `pages` or `app` directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f8d1a62c8321904b845987db6896